### PR TITLE
Fix verify signature commit workflow

### DIFF
--- a/.github/workflows/verify-commits.yml
+++ b/.github/workflows/verify-commits.yml
@@ -2,7 +2,7 @@ name: Ensure Verified Commits
 
 on:
   pull_request:
-  types: [opened, synchronize]
+    types: [opened, synchronize]
 
 jobs:
   verify_commits:


### PR DESCRIPTION
@JanMa That's too bad, it didn't have proper indentation but it didn't warn me in the PR itself. 